### PR TITLE
fix: support import attributes in vue-loader rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
-    "@rsbuild/core": "2.1.2",
+    "@rsbuild/core": "2.1.3",
     "@rsbuild/plugin-less": "^1.6.4",
     "@rslib/core": "^0.23.1",
     "@rslint/core": "^0.6.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,11 +19,11 @@ importers:
         specifier: ^1.61.1
         version: 1.61.1
       '@rsbuild/core':
-        specifier: 2.1.2
-        version: 2.1.2
+        specifier: 2.1.3
+        version: 2.1.3
       '@rsbuild/plugin-less':
         specifier: ^1.6.4
-        version: 1.6.4(@rsbuild/core@2.1.2)(webpack@5.108.3(postcss@8.4.38))
+        version: 1.6.4(@rsbuild/core@2.1.3)(webpack@5.108.3(postcss@8.4.38))
       '@rslib/core':
         specifier: ^0.23.1
         version: 0.23.1(typescript@6.0.3)
@@ -173,6 +173,16 @@ packages:
 
   '@rsbuild/core@2.1.2':
     resolution: {integrity: sha512-EP24Oj01bdwtw/Xl3LiaLe/WG6PBQV2yWbbCh+2TkMDc9dNHiyBTnR+/JZvGxI8RdO5qU0rH4YgMOJ6nVXIQSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
+  '@rsbuild/core@2.1.3':
+    resolution: {integrity: sha512-R2W+eiuPZhUKU2EGyAtUeJMe8LTvyUKbAKTZRfLoZPbSWslMq4t9wLrJY7xVTB/qlUyRl1d/MeP7otvp1HGapA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1201,14 +1211,21 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.1.2)(webpack@5.108.3(postcss@8.4.38))':
+  '@rsbuild/core@2.1.3':
+    dependencies:
+      '@rspack/core': 2.1.2(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.1.3)(webpack@5.108.3(postcss@8.4.38))':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
       less-loader: 12.3.3(less@4.6.4)(webpack@5.108.3(postcss@8.4.38))
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.2
+      '@rsbuild/core': 2.1.3
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   core-js: false
   simple-git-hooks: false
+minimumReleaseAgeExclude:
+  - '@rsbuild/core@2.1.3'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '@rsbuild/core';
 import { type VueLoaderOptions, VueLoaderPlugin } from 'vue-loader';
 import { VueLoader15PitchFixPlugin } from './VueLoader15PitchFixPlugin.js';
+import { patchWebpackRuleSetCompiler } from './patchWebpackRuleSetCompiler.js';
 import { applySplitChunksRule } from './splitChunks.js';
 
 const require = createRequire(import.meta.url);
@@ -102,6 +103,7 @@ export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
         // Support for lang="postcss" and lang="pcss" in SFC
         chain.module.rule(CHAIN_ID.RULE.CSS).test(/\.(?:css|postcss|pcss)$/);
 
+        patchWebpackRuleSetCompiler();
         chain.plugin(CHAIN_ID.PLUGIN.VUE_LOADER_PLUGIN).use(VueLoaderPlugin);
         // we could remove this once a new vue-loader@15 is released with https://github.com/vuejs/vue-loader/pull/2071 shipped
         chain.plugin('vue-loader-15-pitch-fix').use(VueLoader15PitchFixPlugin);

--- a/src/patchWebpackRuleSetCompiler.ts
+++ b/src/patchWebpackRuleSetCompiler.ts
@@ -1,0 +1,75 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const PATCHED_RULE_SET_COMPILER = '__rsbuildPluginVue2PatchedWithRule';
+
+type RuleSetPlugin = {
+  ruleProperty?: string;
+};
+
+type RuleSetCompilerConstructor = {
+  new (plugins?: RuleSetPlugin[]): object;
+  [PATCHED_RULE_SET_COMPILER]?: true;
+};
+
+type ObjectMatcherRulePluginConstructor = new (
+  ruleProperty: string,
+  dataProperty?: string,
+  additionalConditionFunction?: (value: unknown) => boolean,
+) => RuleSetPlugin;
+
+/**
+ * vue-loader@15 uses webpack's RuleSetCompiler to clone user rules, while
+ * Rspack supports `rule.with` for import attributes before webpack does.
+ */
+export function patchWebpackRuleSetCompiler() {
+  // vue-loader@15 requires webpack's RuleSetCompiler lazily from its plugin,
+  // so patch the module export before constructing VueLoaderPlugin.
+  const ruleSetCompilerPath =
+    require.resolve('webpack/lib/rules/RuleSetCompiler');
+  const ObjectMatcherRulePlugin =
+    require('webpack/lib/rules/ObjectMatcherRulePlugin') as ObjectMatcherRulePluginConstructor;
+  const RuleSetCompiler = require(
+    ruleSetCompilerPath,
+  ) as RuleSetCompilerConstructor;
+
+  if (RuleSetCompiler[PATCHED_RULE_SET_COMPILER]) {
+    return;
+  }
+
+  class PatchedRuleSetCompiler extends RuleSetCompiler {
+    constructor(plugins: RuleSetPlugin[] = []) {
+      // Newer webpack versions already support `with`; avoid installing the
+      // same matcher twice if vue-loader eventually gains it upstream.
+      const hasWithRule = plugins.some(
+        (plugin) => plugin?.ruleProperty === 'with',
+      );
+
+      super(
+        hasWithRule
+          ? plugins
+          : [
+              ...plugins,
+              // Rspack stores import attributes in `attributes`, matching
+              // webpack's own NormalModuleFactory rule compiler behavior.
+              new ObjectMatcherRulePlugin('with', 'attributes', (value) =>
+                Boolean(
+                  value &&
+                  !(value as { _isLegacyAssert?: unknown })._isLegacyAssert,
+                ),
+              ),
+            ],
+      );
+    }
+  }
+
+  PatchedRuleSetCompiler[PATCHED_RULE_SET_COMPILER] = true;
+
+  // Replace the cached export so vue-loader's later `require()` receives the
+  // patched constructor while the original package files remain untouched.
+  const cachedModule = require.cache[ruleSetCompilerPath];
+  if (cachedModule) {
+    cachedModule.exports = PatchedRuleSetCompiler;
+  }
+}


### PR DESCRIPTION
## Summary

This PR updates `@rsbuild/core` to 2.1.3 and keeps `vue-loader@15` compatible with Rspack rules that use `with` for import attributes. `vue-loader@15` clones user rules through webpack's `RuleSetCompiler`, so this patch adds the missing `with` matcher before `VueLoaderPlugin` is applied.

## Related Links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.1.3