### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@rsbuild/plugin-less": "^1.6.4",
     "@rslib/core": "^0.23.1",
     "@rslint/core": "^0.6.4",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.11.1",
     "@rstest/playwright": "^0.11.1",
     "@types/node": "^24.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@rslint/core':
         specifier: ^0.6.4
         version: 0.6.4
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.11.1
         version: 0.11.1
@@ -432,6 +435,9 @@ packages:
         optional: true
       '@swc/helpers':
         optional: true
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.11.1':
     resolution: {integrity: sha512-9iJnDrM/zYuHyk1//CMr/Jer2XughgN3fYagGb1YWpMLUke+E+WXlUPgACwf7OkmIB47/TttbLFK+4zwGDNOFg==}
@@ -1640,6 +1646,8 @@ snapshots:
       '@rspack/binding': 2.1.3
     optionalDependencies:
       '@swc/helpers': 0.5.23
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.11.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
+  - '@rstackjs/test-utils@0.2.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,4 +6,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,1 +1,0 @@
-export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,14 +1,1 @@
-const portMap = new Map();
-
-export function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 30000) + 15000,
-) {
-  let port = defaultPort;
-  while (true) {
-    if (!portMap.get(port)) {
-      portMap.set(port, 1);
-      return port;
-    }
-    port++;
-  }
-}
+export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/sfc-basic/rsbuild.config.ts
+++ b/test/sfc-basic/rsbuild.config.ts
@@ -5,6 +5,6 @@ import { getRandomPort } from '../helper';
 export default defineConfig({
   plugins: [pluginVue2()],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/sfc-basic/rsbuild.config.ts
+++ b/test/sfc-basic/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [pluginVue2()],

--- a/test/sfc-css-modules/rsbuild.config.ts
+++ b/test/sfc-css-modules/rsbuild.config.ts
@@ -5,6 +5,6 @@ import { getRandomPort } from '../helper';
 export default defineConfig({
   plugins: [pluginVue2()],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/sfc-css-modules/rsbuild.config.ts
+++ b/test/sfc-css-modules/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [pluginVue2()],

--- a/test/sfc-lang-pcss/rsbuild.config.ts
+++ b/test/sfc-lang-pcss/rsbuild.config.ts
@@ -5,6 +5,6 @@ import { getRandomPort } from '../helper';
 export default defineConfig({
   plugins: [pluginVue2()],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/sfc-lang-pcss/rsbuild.config.ts
+++ b/test/sfc-lang-pcss/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [pluginVue2()],

--- a/test/sfc-lang-postcss/rsbuild.config.ts
+++ b/test/sfc-lang-postcss/rsbuild.config.ts
@@ -5,6 +5,6 @@ import { getRandomPort } from '../helper';
 export default defineConfig({
   plugins: [pluginVue2()],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/sfc-lang-postcss/rsbuild.config.ts
+++ b/test/sfc-lang-postcss/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [pluginVue2()],

--- a/test/sfc-lang-ts/rsbuild.config.ts
+++ b/test/sfc-lang-ts/rsbuild.config.ts
@@ -5,6 +5,6 @@ import { getRandomPort } from '../helper';
 export default defineConfig({
   plugins: [pluginVue2()],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });

--- a/test/sfc-lang-ts/rsbuild.config.ts
+++ b/test/sfc-lang-ts/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [pluginVue2()],

--- a/test/sfc-style/rsbuild.config.ts
+++ b/test/sfc-style/rsbuild.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 export default defineConfig({
   plugins: [pluginVue2(), pluginLess()],

--- a/test/sfc-style/rsbuild.config.ts
+++ b/test/sfc-style/rsbuild.config.ts
@@ -6,6 +6,6 @@ import { getRandomPort } from '../helper';
 export default defineConfig({
   plugins: [pluginVue2(), pluginLess()],
   server: {
-    port: getRandomPort(),
+    port: await getRandomPort(),
   },
 });


### PR DESCRIPTION
This PR replaces the local random-port helper with `@rstackjs/test-utils` so test servers verify port availability through the shared ecosystem implementation. Rsbuild configs now await the asynchronous helper.